### PR TITLE
Added compiler installs needed to build paropt

### DIFF
--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -189,8 +189,10 @@ install_ipopt() {
 
 install_paropt() {
     bkp_dir paropt
-    conda install -c anaconda gxx_linux-64 --yes;
-    conda install -c anaconda gfortran_linux-64 --yes;
+    echo ">>> Installing gxx_linux-64 and gfortran_linux-64";
+    conda install -v -c conda-forge gxx_linux-64 --yes;
+    conda install -v -c conda-forge gfortran_linux-64;
+    echo ">>> Done installing gxx_linux-64 and gfortran_linux-64";
 
     git clone https://github.com/gjkennedy/paropt
     pushd paropt

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -193,7 +193,7 @@ install_paropt() {
     bkp_dir paropt
     echo ">>> Installing gxx_linux-64 and gfortran_linux-64";
     conda install -v -c conda-forge gxx_linux-64 --yes;
-    conda install -v -c conda-forge gfortran_linux-64;
+    conda install -v -c conda-forge gfortran_linux-64 --yes;
     echo ">>> Done installing gxx_linux-64 and gfortran_linux-64";
 
     git clone https://github.com/gjkennedy/paropt

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -19,6 +19,7 @@ INCLUDE_PAROPT=0
 BUILD_TIME=`date +%s`
 
 set -x
+ssh openmdao@web543.webfaction.com ls /home/openmdao/snopt_source
 
 usage() {
 cat <<USAGE

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -83,6 +83,9 @@ while getopts ":b:hl:np:s:a" opt; do
         s)
             INCLUDE_SNOPT=1
             SNOPT_DIR="$OPTARG"
+            ls
+            ls SNOPT
+
             if [ ! -d "$SNOPT_DIR" ]; then
                 echo "Specified SNOPT source dir $SNOPT_DIR doesn't exist."
                 exit 1

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -x
+#!/usr/bin/env bash
 # Finds/downloads and unpacks pyOptSparse, IPOPT, and deps source
 # archives to current directory. Chdirs to each directory in turn
 # to build and install each package (except for pyOptSparse if
@@ -189,6 +189,7 @@ install_ipopt() {
 
 install_paropt() {
     bkp_dir paropt
+    set -x
     echo ">>> Installing gxx_linux-64 and gfortran_linux-64";
     conda install -v -c conda-forge gxx_linux-64 --yes;
     conda install -v -c conda-forge gfortran_linux-64;

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -189,6 +189,8 @@ install_ipopt() {
 
 install_paropt() {
     bkp_dir paropt
+    conda install -c anaconda gxx_linux-64 --yes;
+    conda install -c anaconda gfortran_linux-64 --yes;
 
     git clone https://github.com/gjkennedy/paropt
     pushd paropt

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -200,7 +200,8 @@ install_paropt() {
     pushd paropt
     cp Makefile.in.info Makefile.in
     make PAROPT_DIR=$PWD
-    CFLAGS='-stdlib=libc++' python setup.py install
+    # CFLAGS='-stdlib=libc++' python setup.py install
+    python setup.py install
     popd
  }
 

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -203,8 +203,8 @@ install_ipopt() {
 install_paropt() {
     bkp_dir paropt
     echo ">>> Installing gxx_linux-64 and gfortran_linux-64";
-    conda install -v -c conda-forge gxx_linux-64 --yes;
-    conda install -v -c conda-forge gfortran_linux-64 --yes;
+    #    conda install -v -c conda-forge gxx_linux-64 --yes;
+    #    conda install -v -c conda-forge gfortran_linux-64 --yes;
     echo ">>> Done installing gxx_linux-64 and gfortran_linux-64";
 
     git clone https://github.com/gjkennedy/paropt

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -11,7 +11,7 @@ HSL_VER=2014.01.17
 PREFIX=$HOME/ipopt
 LINEAR_SOLVER=MUMPS
 BUILD_PYOPTSPARSE=1
-PYOPTSPARSE_BRANCH=v2.1.0
+PYOPTSPARSE_BRANCH=v2.1.3
 COMPILER_SUITE=GNU
 INCLUDE_SNOPT=0
 SNOPT_DIR=SNOPT
@@ -220,7 +220,7 @@ build_pyoptsparse() {
                 sed -i -e "s/'coinhsl', //;s/, 'blas', 'lapack'//" pyoptsparse/pyoptsparse/pyIPOPT/setup.py
                 ;;
         esac
-    elif [ "$PYOPTSPARSE_BRANCH" = "v2.1.0" ]; then
+    elif [ "$PYOPTSPARSE_BRANCH" = "v2.1.3" ]; then
         case $patch_type in
             mumps)
                 sed -i -e 's/coinhsl/coinmumps", "coinmetis/' pyoptsparse/pyoptsparse/pyIPOPT/setup.py
@@ -235,7 +235,7 @@ build_pyoptsparse() {
         rsync -a --exclude snopth.f "${SNOPT_DIR}/" ./pyoptsparse/pyoptsparse/pySNOPT/source/
     fi
 
-    if [ "$PYOPTSPARSE_BRANCH" = "v2.1.0" ] && [ $INCLUDE_PAROPT = 1 ] ; then
+    if [ "$PYOPTSPARSE_BRANCH" = "v2.1.3" ] && [ $INCLUDE_PAROPT = 1 ] ; then
     echo ">>> Installing paropt";
       install_paropt
     fi

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -220,7 +220,8 @@ build_pyoptsparse() {
     patch_type=$1
 
     bkp_dir pyoptsparse
-    git clone -b "$PYOPTSPARSE_BRANCH" https://github.com/mdolab/pyoptsparse.git
+#    git clone -b "$PYOPTSPARSE_BRANCH" https://github.com/mdolab/pyoptsparse.git
+    git clone -b PSQP-informs https://github.com/sseraj/pyoptsparse.git
 
     if [ "$PYOPTSPARSE_BRANCH" = "v1.2" ]; then
         case $patch_type in

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -x
 # Finds/downloads and unpacks pyOptSparse, IPOPT, and deps source
 # archives to current directory. Chdirs to each directory in turn
 # to build and install each package (except for pyOptSparse if

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -83,10 +83,16 @@ while getopts ":b:hl:np:s:a" opt; do
         s)
             INCLUDE_SNOPT=1
             SNOPT_DIR="$OPTARG"
-            ls
-            ls SNOPT
+            set -x
+            echo "ls SNOPT"
+            ls -l
+            ls -l SNOPT
 
             if [ ! -d "$SNOPT_DIR" ]; then
+                set -x
+                echo "ls SNOPT"
+                ls -l SNOPT
+
                 echo "Specified SNOPT source dir $SNOPT_DIR doesn't exist."
                 exit 1
             fi

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -20,6 +20,7 @@ BUILD_TIME=`date +%s`
 
 set -x
 ssh openmdao@web543.webfaction.com ls /home/openmdao/snopt_source
+ssh openmdao@web543.webfaction.com ls /home/openmdao/snopt_source/snopt77
 
 usage() {
 cat <<USAGE

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -18,6 +18,8 @@ SNOPT_DIR=SNOPT
 INCLUDE_PAROPT=0
 BUILD_TIME=`date +%s`
 
+set -x
+
 usage() {
 cat <<USAGE
 Download, configure, build, and install pyOptSparse with IPOPT
@@ -189,7 +191,6 @@ install_ipopt() {
 
 install_paropt() {
     bkp_dir paropt
-    set -x
     echo ">>> Installing gxx_linux-64 and gfortran_linux-64";
     conda install -v -c conda-forge gxx_linux-64 --yes;
     conda install -v -c conda-forge gfortran_linux-64;
@@ -234,6 +235,7 @@ build_pyoptsparse() {
     fi
 
     if [ "$PYOPTSPARSE_BRANCH" = "v2.1.0" ] && [ $INCLUDE_PAROPT = 1 ] ; then
+    echo ">>> Installing paropt";
       install_paropt
     fi
 

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -221,9 +221,10 @@ build_pyoptsparse() {
 
     bkp_dir pyoptsparse
 #    git clone -b "$PYOPTSPARSE_BRANCH" https://github.com/mdolab/pyoptsparse.git
-    git clone -b PSQP-informs https://github.com/sseraj/pyoptsparse.git
+#    git clone -b PSQP-informs https://github.com/sseraj/pyoptsparse.git
 
     if [ "$PYOPTSPARSE_BRANCH" = "v1.2" ]; then
+        git clone -b "$PYOPTSPARSE_BRANCH" https://github.com/mdolab/pyoptsparse.git
         case $patch_type in
             mumps)
                 sed -i -e "s/coinhsl/coinmumps', 'coinmetis/" pyoptsparse/pyoptsparse/pyIPOPT/setup.py
@@ -233,6 +234,7 @@ build_pyoptsparse() {
                 ;;
         esac
     elif [ "$PYOPTSPARSE_BRANCH" = "v2.1.3" ]; then
+        git clone -b PSQP-informs https://github.com/sseraj/pyoptsparse.git
         case $patch_type in
             mumps)
                 sed -i -e 's/coinhsl/coinmumps", "coinmetis/' pyoptsparse/pyoptsparse/pyIPOPT/setup.py


### PR DESCRIPTION
conda install some 64 bit compilers.

These installs cause problems for installing Metis. But since the build script installs Metis before ParOpt, and these compiler installs are placed after the Metis install and before the ParOpt install.

Updated to default to the latest version of Pyoptsparse which supports ParOpt and does not have bugs with PQSP.