### PR TITLE
Create a temporary working dir and double-check SNOPT dir layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Depending on which options are chosen, it may perform some minor patching to all
 ## Usage
 ```
 build_pyoptsparse.sh [-b branch] [-h] [-l linear_solver] [-n] [-p prefix] [-s snopt_dir] [-a]
+    -a                Include ParOpt. Default: no ParOpt
     -b branch         pyOptSparse git branch. Default: v2.1.5
+    -d                Do not erase the build directory after completion.
     -h                Display usage and exit.
     -l linear_solver  One of mumps, hsl, or pardiso. Default: mumps
     -n                Prepare, but do NOT build/install pyOptSparse.
@@ -18,7 +20,6 @@ build_pyoptsparse.sh [-b branch] [-h] [-l linear_solver] [-n] [-p prefix] [-s sn
                       this dir, the build may fail. If it does, rename
                       the directory or removing the old versions.
     -s snopt_dir      Include SNOPT from snopt_dir. Default: no SNOPT
-    -a                Include ParOpt. Default: no ParOpt
 
 NOTES:
     If HSL is selected as the linear solver, the


### PR DESCRIPTION
A subdirectory with a unique name is now created to work in (perform downloads and builds). This directory is removed if the build is successful, unless the -d switch is used.

SNOPT_DIR is converted to an absolute path since a relative path might be invalid in the new working dir. The SNOPT_DIR structure is also checked to determine whether the top level dir is referenced or the `src` subdir. Without this second step, the pyOptSparse build would have silently ignored SNOPT if it didn't see `snoptc.f`.

Resolves #9 
