### PR TITLE
Multiple fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage:
     -l linear_solver  One of mumps, hsl, or pardiso. Default: mumps
     -n                Prepare, but do NOT build/install pyOptSparse.
                         Default: build & install
-    -p prefix         Where to install. Default: /Users/tkollar/ipopt
+    -p prefix         Where to install. Default: $HOME/ipopt
                       Note: If older versions are already installed in
                       this dir, the build may fail. If it does, rename
                       the directory or remove the old versions.

--- a/README.md
+++ b/README.md
@@ -5,20 +5,28 @@ By default, the script uses MUMPS, but if HSL or PARDISO are available, it can u
 
 Depending on which options are chosen, it may perform some minor patching to allow the build to succeed.
 
+The script expects gcc, g++, and gfortran to be available (unless -i is used). It also checks for python and pip, asking for confirmation if they appear to be a system installation rather than a personal one / virtual environment.
+
 ## Usage
 ```
-build_pyoptsparse.sh [-b branch] [-h] [-l linear_solver] [-n] [-p prefix] [-s snopt_dir] [-a]
+Usage:
+./build_pyoptsparse.sh [-a] [-b branch] [-d] [-f] [-g] [-h] [-i] [-l linear_solver]
+    [-n] [-p prefix] [-s snopt_dir]
+
     -a                Include ParOpt. Default: no ParOpt
     -b branch         pyOptSparse git branch. Default: v2.1.5
     -d                Do not erase the build directory after completion.
+    -f                Skip Python system vs. personal installation check.
+    -g                Skip compiler functionality check.
     -h                Display usage and exit.
+    -i                Use Intel compiler suite instead of GNU.
     -l linear_solver  One of mumps, hsl, or pardiso. Default: mumps
     -n                Prepare, but do NOT build/install pyOptSparse.
                         Default: build & install
-    -p prefix         Where to install. Default: $HOME/ipopt
+    -p prefix         Where to install. Default: /Users/tkollar/ipopt
                       Note: If older versions are already installed in
                       this dir, the build may fail. If it does, rename
-                      the directory or removing the old versions.
+                      the directory or remove the old versions.
     -s snopt_dir      Include SNOPT from snopt_dir. Default: no SNOPT
 
 NOTES:
@@ -28,7 +36,7 @@ NOTES:
 
     If PARDISO is selected as the linear solver, the Intel compiler suite
     with MKL must be available.
-    
+
     Examples:
       ./build_pyoptsparse.sh
       ./build_pyoptsparse.sh -l pardiso

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -30,7 +30,7 @@ support and dependencies. A temporary working directory is created,
 which is removed if the installation succeeds unless -d is used.
 
 Usage:
-$0 [-a] [-b branch] [-d] [-f] [-g] [-h] [-l linear_solver]
+$0 [-a] [-b branch] [-d] [-f] [-g] [-h] [-i] [-l linear_solver]
     [-n] [-p prefix] [-s snopt_dir]
 
     -a                Include ParOpt. Default: no ParOpt
@@ -39,6 +39,7 @@ $0 [-a] [-b branch] [-d] [-f] [-g] [-h] [-l linear_solver]
     -f                Skip Python system vs. personal installation check.
     -g                Skip compiler functionality check.
     -h                Display usage and exit.
+    -i                Use Intel compiler suite instead of GNU.
     -l linear_solver  One of mumps, hsl, or pardiso. Default: mumps
     -n                Prepare, but do NOT build/install pyOptSparse.
                         Default: build & install
@@ -64,7 +65,7 @@ USAGE
     exit 3
 }
 
-while getopts ":ab:dfghl:np:s:" opt; do
+while getopts ":ab:dfghil:np:s:" opt; do
     case ${opt} in
         a)
             INCLUDE_PAROPT=1 ;;
@@ -78,6 +79,8 @@ while getopts ":ab:dfghl:np:s:" opt; do
             CHECK_COMPILER_COMPAT=0 ;;
         h)
             usage ;;
+        i)
+            COMPILER_SUITE=Intel ;;
         l)
             case ${OPTARG^^} in
                 MUMPS|HSL)

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -79,7 +79,7 @@ while getopts ":ab:dfghil:np:s:" opt; do
         f)
             CHECK_PY_INST_TYPE=0 ;;
         g)
-            CHECK_COMPILER_COMPAT=0 ;;
+            CHECK_COMPILER_FUNCTION=0 ;;
         h)
             usage ;;
         i)
@@ -313,7 +313,7 @@ install_paropt() {
     cp Makefile.in.info Makefile.in
     make -j $CORES PAROPT_DIR=$PWD
     # In some cases needed to set this CFLAGS
-    # CFLAGS='-stdlib=libc++'  setup.py install
+    # CFLAGS='-stdlib=libc++' python setup.py install
     $PY setup.py install
     popd
  }


### PR DESCRIPTION
The following changes were made:

ParOpt-specific:
- Compiler installation is only attempted if a Travis build is detected
- `mpicxx` availability is added as a dependency
- Cython is pip-installed

Other areas:
- Basic compiler functionality is pretested for each of the C, C++, and FORTRAN compilers
- If a "system" Python installation is being used instead of a personal/virtual, confirmation is requested to proceed (skipped on Travis)
- Script won't continue if Python 3.x is not detected
- `numpy` is pip-installed prior to the pyOptSparse build
- The script detects the number of cores in the system, and does a parallel build using 50% (if there's more than one)
- Options added to skip the compiler and python tests
- A message about setting LD_LIBRARY_PATH or DYLD_LIBRARY_PATH is displayed at the successful completion of the script
- README.md was updated with the newest usage
