### PR TITLE
Fixed -l switch to work with older versions of bash

### DIFF
--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -92,12 +92,13 @@ while getopts ":ab:dfghil:np:s:t:" opt; do
         i)
             COMPILER_SUITE=Intel ;;
         l)
-            case ${OPTARG^^} in
+            LS_UP=`echo $OPTARG | tr [:lower:] [:upper:]`
+            case $LS_UP in
                 MUMPS|HSL)
-                    LINEAR_SOLVER=${OPTARG^^}
+                    LINEAR_SOLVER=$LS_UP
                     COMPILER_SUITE=GNU ;;
                 PARDISO)
-                    LINEAR_SOLVER=${OPTARG^^}
+                    LINEAR_SOLVER=PARDISO
                     COMPILER_SUITE=Intel ;;
                 *)
                     echo "Unrecognized linear solver specified."


### PR DESCRIPTION
Older versions of bash didn't recognize the ${OPTARG^^} syntax to capitalize the value of an environment variable.