### PR TITLE
Add arg to MUMPS configuration

### DIFF
--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -411,7 +411,7 @@ install_with_mumps() {
     ./configure --with-metis --with-metis-lflags="-L${PREFIX}/lib -lcoinmetis" \
        --with-metis-cflags="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
        --prefix=$PREFIX CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
-       FCFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
+       FCFLAGS="-fallow-argument-mismatch -I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
     make -j $CORES
     make install
     popd


### PR DESCRIPTION
-fallow-argument-mismatch is added to address issues building with GCC >= 10, as recommended in the thread here https://github.com/coin-or/coinbrew/issues/47
and/or here: https://github.com/coin-or-tools/ThirdParty-Mumps/issues/4
.

(I'm not sure if this will break things for GCC < 10 or if there's a better fix out there.)