### PR TITLE
Add arg to MUMPS configuration for GCC >= 10

### DIFF
--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -411,7 +411,7 @@ install_with_mumps() {
     ./configure --with-metis --with-metis-lflags="-L${PREFIX}/lib -lcoinmetis" \
        --with-metis-cflags="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
        --prefix=$PREFIX CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
-       FCFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
+       FCFLAGS="-fallow-argument-mismatch -I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
     make -j $CORES
     make install
     popd

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -158,6 +158,7 @@ case $COMPILER_SUITE in
         CC=gcc
         CXX=g++
         FC=gfortran
+        GCCMAJORVER=`gcc -dumpversion | cut -f1 -d.`
         ;;
     Intel)
         CC=icc
@@ -408,10 +409,16 @@ install_with_mumps() {
     git clone -b $MUMPS_BRANCH https://github.com/coin-or-tools/ThirdParty-Mumps.git
     pushd ThirdParty-Mumps
     ./get.Mumps
+
+    # for GCC>=10, see Issue #30
+    if [[ $GCCMAJORVER -ge 10 ]]; then
+        ALLOW_MISMATCH='-fallow-argument-mismatch'
+    fi
+
     ./configure --with-metis --with-metis-lflags="-L${PREFIX}/lib -lcoinmetis" \
        --with-metis-cflags="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
        --prefix=$PREFIX CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
-       FCFLAGS="-fallow-argument-mismatch -I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
+       FCFLAGS="${ALLOW_MISMATCH} -I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
     make -j $CORES
     make install
     popd

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -410,7 +410,7 @@ install_with_mumps() {
     pushd ThirdParty-Mumps
     ./get.Mumps
 
-    # for GCC>=10, see Issue #30
+    # for GCC>=10, see Issue #29
     if [[ $GCCMAJORVER -ge 10 ]]; then
         ALLOW_MISMATCH='-fallow-argument-mismatch'
     fi


### PR DESCRIPTION
### Summary

Updated version of PR #30 making the fix conditional on GCC version:
```
-fallow-argument-mismatch is added to address issues building with GCC >= 10, as recommended in the thread here https://github.com/coin-or/coinbrew/issues/47
and/or here: https://github.com/coin-or-tools/ThirdParty-Mumps/issues/4
```

### Related Issues

- Resolves #29

### Backwards incompatibilities

None

### New Dependencies

None