### PR TITLE
Set IPOPT_DIR for pyOptSparse>=2.9.0

### DIFF
--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -765,6 +765,7 @@ def install_pyoptsparse_from_src():
     if opts['include_ipopt'] is True:
         os.environ['IPOPT_INC'] = get_coin_inc_dir()
         os.environ['IPOPT_LIB'] = str(Path(opts["prefix"]) / 'lib')
+        os.environ['IPOPT_DIR'] = str(Path(opts["prefix"]))
     os.environ['CFLAGS'] = '-Wno-implicit-function-declaration -std=c99'
 
     # Pull in SNOPT source:

--- a/build_pyoptsparse.sh
+++ b/build_pyoptsparse.sh
@@ -396,6 +396,7 @@ build_pyoptsparse() {
         # Necessary for pyoptsparse to find IPOPT:
         export IPOPT_INC=$PREFIX/include/coin-or
         export IPOPT_LIB=$PREFIX/lib
+        export IPOPT_DIR=$PREFIX
         export CFLAGS='-Wno-implicit-function-declaration' 
         $PY -m pip install --no-cache-dir ./pyoptsparse
     else


### PR DESCRIPTION
Set in both `build_pyoptsparse.py` and `build_pyoptsparse.sh`