### PR TITLE
Fixed issues with setuptools and paropt

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -226,7 +226,7 @@ jobs:
           echo "============================================================="
           python -m pip_audit
 
-      - name: Slack deprecation warnings
+      - name: Slack audit warnings
         if: steps.audit.outcome == 'failure'
         uses: act10ns/slack@v2.0.0
         with:

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Run the workflow Sundays at 0400 UTC
+  schedule:
+    - cron: '0 4 * * 0'
+
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
 
   tests:

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -25,7 +25,7 @@ jobs:
             SCIPY: 1.7
             MPI4PY: true
             PYOPTSPARSE: 'v2.8.3'
-            PAROPT: true
+            # PAROPT: true
             SNOPT: 7.7
 
           # test baseline versions on MacOS
@@ -36,7 +36,7 @@ jobs:
             SCIPY: 1
             MPI4PY: true
             PYOPTSPARSE: 'latest'
-            PAROPT: true
+            # PAROPT: true
             SNOPT: 7.7
 
           # test latest versions
@@ -47,7 +47,7 @@ jobs:
             SCIPY: 1
             MPI4PY: true
             PYOPTSPARSE: 'latest'
-            PAROPT: true
+            # PAROPT: true
             SNOPT: 7.7
 
           # test oldest supported versions
@@ -180,7 +180,7 @@ jobs:
               echo "HSL was requested but source is not available, using default linear solver."
               echo "---------------------------------------------------------------------------"
             fi
-          elif [[ "${{  matrix.LINEAR_SOLVER }}" == "pardiso" ]]; then
+          elif [[ "${{ matrix.LINEAR_SOLVER }}" == "pardiso" ]]; then
             echo "-------------------------------------------------------------------------------"
             echo "Pardiso requires Intel compilers, which are not installed. The build will fail."
             echo "-------------------------------------------------------------------------------"
@@ -209,6 +209,8 @@ jobs:
           testflo --pre_announce --show_skipped .
 
       - name: Audit dependencies
+        id: audit
+        continue-on-error: true
         run: |
           python -m pip install pip-audit
 
@@ -216,6 +218,16 @@ jobs:
           echo "Scan environment for packages with known vulnerabilities"
           echo "============================================================="
           python -m pip_audit
+
+      - name: Slack deprecation warnings
+        if: steps.audit.outcome == 'failure'
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: 'warning'
+          message: |
+            pip-audit detected vulnerabilities.
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Notify slack
         uses: act10ns/slack@v1

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -32,7 +32,7 @@ jobs:
             SCIPY: 1.7
             MPI4PY: true
             PYOPTSPARSE: 'v2.8.3'
-            # PAROPT: true
+            PAROPT: true
             SNOPT: 7.7
 
           # test baseline versions on MacOS
@@ -43,7 +43,7 @@ jobs:
             SCIPY: 1
             MPI4PY: true
             PYOPTSPARSE: 'latest'
-            # PAROPT: true
+            PAROPT: true
             SNOPT: 7.7
 
           # test latest versions
@@ -54,7 +54,7 @@ jobs:
             SCIPY: 1
             MPI4PY: true
             PYOPTSPARSE: 'latest'
-            # PAROPT: true
+            PAROPT: true
             SNOPT: 7.7
 
           # test oldest supported versions

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -11,6 +11,7 @@ import tempfile
 from colors import *
 from shutil import which
 from packaging.version import Version, parse
+import setuptools
 
 # Default options that the user can change with command line switches
 opts = {
@@ -251,7 +252,6 @@ def process_command_line():
     opts['verbose'] = args.verbose
     opts['uninstall'] = args.uninstall
 
-
 def announce(msg:str):
     """
     Print an important message in color with a line above and below.
@@ -471,7 +471,6 @@ def run_conda_cmd(cmd_args):
     cmd_list = [opts['conda_cmd']]
     cmd_list.extend(cmd_args)
     return run_cmd(cmd_list)
-
 
 def pip_install(pip_install_args, pkg_desc='packages'):
     """
@@ -915,15 +914,21 @@ def install_pyoptsparse_from_src():
     if opts['build_pyoptsparse'] is True:
         patch_pyoptsparse_src()
 
-        # `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
-        # of the deprecation of `distutils` itself. It will be removed for
-        # Python >= 3.12. For older Python versions it will remain present.
-        # It is recommended to use `setuptools < 60.0` for those Python versions.
-        # For more details, see:
-        # https://numpy.org/devdocs/reference/distutils_status_migration.html
-        pip_install(pip_install_args=['setuptools<66.0'], pkg_desc='setuptools')
-
-        pip_install(pip_install_args=['--no-cache-dir', './'], pkg_desc='pyoptsparse')
+        python_ver = Version(platform.python_version())
+        stools_ver = Version(setuptools.__version__)
+        if python_ver < Version('3.12.0') and stools_ver >= Version('66.0'):
+            # `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
+            # of the deprecation of `distutils` itself. It will be removed for
+            # Python >= 3.12. For older Python versions it will remain present.
+            # It is recommended to use `setuptools < 60.0` for those Python versions.
+            # For more details, see:
+            # https://numpy.org/devdocs/reference/distutils_status_migration.html
+            pip_install(pip_install_args=['setuptools<66.0'], pkg_desc='setuptools<66.0')
+            pip_install(pip_install_args=['--no-cache-dir', './'], pkg_desc='pyoptsparse')
+            pip_install(pip_install_args=[f'setuptools=={stools_ver}'],
+                        pkg_desc='previous version of setuptools')
+        else:
+            pip_install(pip_install_args=['--no-cache-dir', './'], pkg_desc='pyoptsparse')
     else:
         announce('Not building pyOptSparse by request')
         if opts['include_ipopt'] is True:

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -89,7 +89,7 @@ build_info = {
         'include_file': 'CoinHslConfig.h'
     },
     'paropt': {
-        'branch': '',
+        'branch': 'v2.1.4',
         'url': 'https://github.com/smdogroup/paropt.git',
         'src_lib_glob': 'libparopt*',
     }

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -704,7 +704,7 @@ def install_paropt_from_src():
     Path('Makefile.in.info').rename('Makefile.in')
     make_vars =  [f'PAROPT_DIR={Path.cwd()}']
     if sys_info['sys_name'] == 'Darwin':
-        make_vars.extend(['SO_EXT=so', 'SO_LINK_FLAGS=-fPIC -dynamiclib -undefined dynamic_lookup',
+        make_vars.extend(['SO_EXT=dylib', 'SO_LINK_FLAGS=-fPIC -dynamiclib -undefined dynamic_lookup',
                           f'METIS_INCLUDE=-I{os.environ["METIS_DIR"]}/include/',
                           f'METIS_LIB=-L{os.environ["METIS_DIR"]}/lib/',
                           '-lmetis'])


### PR DESCRIPTION
### Summary

Fixes the following issues:

- Older version of `setuptools` are incompatible with the recently released Python 3.12:
  - Only install old version of `setuptools` for Python older than 3.12 (if necessary)
  - If version of `setuptools` is changed, revert back to previously installed version

- Versions of `paropt` older than `v2.1.3` are incompatible with the recently released Cython 3.0:
  - Changed to use paropt [v2.1.4](https://github.com/smdogroup/paropt/releases/tag/v2.1.4)
  - The build flags for OSX were changed to those specified in [Makefile.in.info](https://github.com/smdogroup/paropt/blob/6aed60a9b241c57de498cea95b25e232eca9e91a/Makefile.in.info#L26)

- Incorporated the workflow updates from PR #53
  - Since updates are infrequent, I have added a cron trigger to run the test suite once a week
  - I also added a workflow_dispatch trigger to enable on demand testing
  - I changed the audit step to not fail the workflow, but issue a warning

### Related Issues

- Resolves #52
