### PR TITLE
Added test workflow triggers; made audit issue a warning rather than fail

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Run the workflow Sundays at 0400 UTC
+  schedule:
+    - cron: '0 4 * * 0'
+
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
 
   tests:
@@ -180,7 +187,7 @@ jobs:
               echo "HSL was requested but source is not available, using default linear solver."
               echo "---------------------------------------------------------------------------"
             fi
-          elif [[ "${{  matrix.LINEAR_SOLVER }}" == "pardiso" ]]; then
+          elif [[ "${{ matrix.LINEAR_SOLVER }}" == "pardiso" ]]; then
             echo "-------------------------------------------------------------------------------"
             echo "Pardiso requires Intel compilers, which are not installed. The build will fail."
             echo "-------------------------------------------------------------------------------"
@@ -209,6 +216,8 @@ jobs:
           testflo --pre_announce --show_skipped .
 
       - name: Audit dependencies
+        id: audit
+        continue-on-error: true
         run: |
           python -m pip install pip-audit
 
@@ -216,6 +225,16 @@ jobs:
           echo "Scan environment for packages with known vulnerabilities"
           echo "============================================================="
           python -m pip_audit
+
+      - name: Slack audit warnings
+        if: steps.audit.outcome == 'failure'
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: 'warning'
+          message: |
+            pip-audit detected vulnerabilities.
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Notify slack
         uses: act10ns/slack@v1


### PR DESCRIPTION
- Since updates are infrequent, I have added a `cron` trigger to run the test suite once a week
- I also added a `workflow_dispatch` trigger to enable on demand testing
- I changed the `audit` step to not fail the workflow, but issue a warning