### PR TITLE
Update baseline test environment

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -62,7 +62,7 @@ jobs:
             OS: ubuntu-latest
             PY: 3.8
             NUMPY: 1.22
-            SCIPY: 1.8
+            SCIPY: 1.7
             PYOPTSPARSE: 'v1.2'
             NO_IPOPT: true
             SNOPT: 7.2
@@ -227,7 +227,7 @@ jobs:
           python -m pip_audit
 
       - name: Slack audit warnings
-        if: steps.audit.outcome == 'failure'
+        if: steps.audit.outcome == 'failure' && matrix.NAME != 'Ubuntu Oldest'
         uses: act10ns/slack@v2.0.0
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -29,7 +29,7 @@ jobs:
             OS: ubuntu-latest
             PY: '3.11'
             NUMPY: 1.25
-            SCIPY: 1.10
+            SCIPY: 1.11
             MPI4PY: true
             PYOPTSPARSE: 'v2.10.1'
             PAROPT: true

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -27,11 +27,11 @@ jobs:
           # test baseline versions on Ubuntu
           - NAME: Ubuntu Baseline
             OS: ubuntu-latest
-            PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
+            PY: '3.11'
+            NUMPY: 1.25
+            SCIPY: 1.10
             MPI4PY: true
-            PYOPTSPARSE: 'v2.8.3'
+            PYOPTSPARSE: 'v2.10.1'
             PAROPT: true
             SNOPT: 7.7
 
@@ -62,7 +62,7 @@ jobs:
             OS: ubuntu-latest
             PY: 3.8
             NUMPY: 1.22
-            SCIPY: 1.7
+            SCIPY: 1.8
             PYOPTSPARSE: 'v1.2'
             NO_IPOPT: true
             SNOPT: 7.2


### PR DESCRIPTION
Updates to the test workflow:
- use more current versions of Python, NumPy, SciPy and pyOptSparse as the baseline for testing
- do not post alerts for audit failures when testing the oldest supported versions