### PR TITLE
Fix HSL build issues

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -76,6 +76,38 @@ jobs:
             NO_IPOPT: true
             SNOPT: 7.2
 
+          # test baseline versions on Ubuntu without MPI with forced build
+          - NAME: Ubuntu Baseline, no MPI, forced build
+            OS: ubuntu-latest
+            PY: '3.11'
+            NUMPY: 1.25
+            SCIPY: 1.11
+            PYOPTSPARSE: 'default'
+            SNOPT: 7.7
+            FORCE_BUILD: true
+
+          # test baseline versions on MacOS without MPI with forced build
+          - NAME: MacOS Baseline, no MPI, forced build
+            OS: macos-latest
+            PY: '3.11'
+            NUMPY: 1
+            SCIPY: 1
+            MPI4PY: true
+            PYOPTSPARSE: 'default'
+            SNOPT: 7.7
+            FORCE_BUILD: true
+
+          # test latest versions without MPI with forced build
+          - NAME: Ubuntu Latest, no MPI, forced build
+            OS: ubuntu-latest
+            PY: 3
+            NUMPY: 1
+            SCIPY: 1
+            MPI4PY: true
+            PYOPTSPARSE: 'latest'
+            SNOPT: 7.7
+            FORCE_BUILD: true
+
     runs-on: ${{ matrix.OS }}
 
     name: ${{ matrix.NAME }}
@@ -210,8 +242,12 @@ jobs:
             NO_IPOPT="--no-ipopt"
           fi
 
-          echo "build_pyoptsparse -v $BRANCH $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER"
-          build_pyoptsparse -v $BRANCH $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER
+          if [[ "${{ matrix.FORCE_BUILD }}" ]]; then
+            FORCE_BUILD="--force-build"
+          fi
+
+          echo "build_pyoptsparse -v $BRANCH $FORCE_BUILD $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER"
+          build_pyoptsparse -v $BRANCH $FORCE_BUILD $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER
 
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -831,7 +831,7 @@ def install_hsl_from_src():
 
     # Extract the HSL tar file and rename the folder to 'coinhsl'
     # First, determine the name of the top-level folder:
-    with tarfile.open(opts['hsl_tar_file'], 'r:gz') as tf:
+    with tarfile.open(opts['hsl_tar_file'], 'r') as tf:
         hsl_dir_name = tf.getnames()[0]
     run_cmd(cmd_list=['tar', 'xf', opts['hsl_tar_file']]) # Extract
     Path(hsl_dir_name).rename('coinhsl') # Rename

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 import subprocess
+import tarfile
 from pathlib import Path, PurePath
 import tempfile
 from colors import *
@@ -40,6 +41,7 @@ opts = {
 # Information about the host, status, and constants
 sys_info = {
     'gcc_major_ver': -1,
+    'gcc_is_apple_clang': False,
     'line_color': 'white',
     'msg_color': 'gray',
     'gnu_sanity_check_done': False,
@@ -663,13 +665,9 @@ def install_metis():
 
     install_metis_from_src()
 
-def install_mumps_from_src():
-    """ Git clone the MUMPS repo, build the library, and install it and the include files. """
-    if not allow_build('mumps'):
-        return
+def get_common_solver_config_cmd():
+    """ Gets common configuration options for Mumps and HSL solvers. """
 
-    build_dir = git_clone('mumps')
-    run_cmd(['./get.Mumps'])
     coin_dir = get_coin_inc_dir()
     cflags = f'-w -I{opts["prefix"]}/include -I{coin_dir} -I{coin_dir}/metis'
     fcflags = cflags
@@ -677,16 +675,36 @@ def install_mumps_from_src():
         fcflags = '-fallow-argument-mismatch ' + fcflags
 
     metis_lib = get_coin_lib_name('metis')
+    metis_lflags = f'-L{opts["prefix"]}/lib -l{metis_lib}'
+    if platform.system() == "Linux":
+        metis_lflags += ' -lm'
+
     config_opts = [
         '--with-metis',
-        f'--with-metis-lflags=-L{opts["prefix"]}/lib -l{metis_lib} -lm',
+        f'--with-metis-lflags={metis_lflags}',
         f'--with-metis-cflags={cflags}',
         f'--prefix={opts["prefix"]}',
         f'CFLAGS={cflags}',
         f'FCFLAGS={fcflags}'
     ]
+
+    # Disable OpenMP support if we are on macOS building with Apple Clang.
+    if sys_info['gcc_is_apple_clang']:
+        config_opts.append('--disable-openmp')
+
     cnf_cmd_list = ['./configure']
     cnf_cmd_list.extend(config_opts)
+    return cnf_cmd_list
+
+def install_mumps_from_src():
+    """ Git clone the MUMPS repo, build the library, and install it and the include files. """
+    if not allow_build('mumps'):
+        return
+
+    build_dir = git_clone('mumps')
+    run_cmd(['./get.Mumps'])
+
+    cnf_cmd_list = get_common_solver_config_cmd()
 
     note("Running configure")
     run_cmd(cmd_list=cnf_cmd_list)
@@ -813,22 +831,12 @@ def install_hsl_from_src():
 
     # Extract the HSL tar file and rename the folder to 'coinhsl'
     # First, determine the name of the top-level folder:
-    tar = subprocess.run(['tar', 'vtf', opts['hsl_tar_file']], encoding='UTF-8',
-          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    first_line = tar.stdout.splitlines()[0]
-    hsl_dir_name = first_line.split()[8].replace('/','')
+    with tarfile.open(opts['hsl_tar_file'], 'r:gz') as tf:
+        hsl_dir_name = tf.getnames()[0]
     run_cmd(cmd_list=['tar', 'xf', opts['hsl_tar_file']]) # Extract
     Path(hsl_dir_name).rename('coinhsl') # Rename
 
-    coin_dir = get_coin_inc_dir()
-    metis_lib = get_coin_lib_name('metis')
-    cnf_cmd_list = [
-        './configure',
-        f'--prefix={opts["prefix"]}',
-        '--with-metis',
-        f'--with-metis-lflags=-L{opts["prefix"]}/lib -l{metis_lib}',
-        f'--with-mumps-cflags=-I{coin_dir}',
-    ]
+    cnf_cmd_list = get_common_solver_config_cmd()
 
     note("Running configure")
     run_cmd(cmd_list=cnf_cmd_list)
@@ -1199,6 +1207,7 @@ def select_intel_compilers():
     os.environ['CXX'] = 'icpc'
     os.environ['FC'] = 'ifort'
     sys_info['gcc_major_ver'] = -1
+    sys_info['gcc_is_apple_clang'] = False
 
 def select_gnu_compilers():
     """ Set environment variables to use GNU compilers. """
@@ -1207,6 +1216,8 @@ def select_gnu_compilers():
     os.environ['FC'] = 'gfortran'
     gcc_ver = subprocess.run(['gcc', '-dumpversion'], capture_output=True)
     sys_info['gcc_major_ver'] = int(gcc_ver.stdout.decode('UTF-8').split('.')[0])
+    gcc_version = subprocess.run(['gcc', '--version'], capture_output=True)
+    sys_info['gcc_is_apple_clang'] = 'Apple clang' in gcc_version.stdout.decode('UTF-8')
 
 def finish_setup():
     """ Finalize settings based on provided options and environment state. """


### PR DESCRIPTION
### Summary

This PR fixes several build issues when building pyOptSparse with Ipopt and HSL solvers.

The configuration logic for the Mumps and HSL builds was largely the same, so I refactored the common parts into a `get_common_solver_config_cmd` function in order to remove duplication; YMMV on whether this is a good change or not.

This function sets up the arguments for the configure command and in particular:

1. Checks to see if `-lm` needs to be explicitly included. I based this check on whether the OS was Linux or not; this is probably not the most reliable approach and probably merits changing. (It also probably doesn't hurt to just always include `-lm`?)
2. If the compiler is identified as Apple Clang the `--disable-openmp` flag is provided. It's possible to build with OpenMP support, but I figured that wasn't worth it for this (see the "Notes" section below).

I added a new key to the `sys_info` dictionary, `gcc_is_apple_clang`, that is true if the compiled is detected as Apple clang via `gcc --version` and false otherwise since Apple aliases `gcc` and `g++` to `clang` and `clang++` on macOS by default. I added the logic for this flag to the `select_*_compilers` functions.

For the HSL build, the logic to determine the directory name hard-coded the column of the name in the `tar` output, which depends on the `tar` implementation used. This was not working on later versions of Ubuntu. Accordingly, the PR replaces the `subprocess.run` call to `tar` and subsequent parsing with direct use of the `tarfile` module from the Python standard libary.

I tested this with Mumps as the linear solver:
```
./build_pyoptsparse.py -e -v -f 
```
and HSL as the linear solver:
```
./build_pyoptsparse.py -e -l hsl -t ./coinhsl-YYYY-MM-DD.tar.gz -v -f
```
on both Ubuntu 22.04 and macOS and both built successfully.

### Related Issues

- Resolves #61 

### Backwards incompatibilities

None

### New Dependencies

The script now imports `tarfile`, but this is a part of the Python standard library and isn't really a new external dependency.

### Notes

It's possible to build Ipopt with Apple clang and OpenMP, but it requires the following:

1. OpenMP must be installed via Homebrew or a similar tool.
2. `CPPFLAGS` must be include `-Xpreprocessor -fopenmp`
3. `CFLAGS` and `CXXFLAGS` must include `"-I$OMP_PATH/include"`
4. `LFLAGS` must include `"-Wl,-rpath,$OMP_PATH/lib -L$OMP_PATH/lib -lomp"`

The value of `OMP_PATH` above depends on the method of installation but is probably `/opt/homebrew/opt/libomp` for Homebrew on Apple Silicon.

I believe I also had to manually fix the output of the `coinhsl.pc` file for Ipopt when I last built it with OpenMP support on macOS.