### PR TITLE
Removed ensurepip from test workflow

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -197,8 +197,6 @@ jobs:
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} compilers cython swig -q -y
 
-          python -m ensurepip --upgrade
-
           echo "============================================================="
           echo "Install build_pyoptsparse"
           echo "============================================================="


### PR DESCRIPTION
### Summary

Using `ensurepip`  in the test workflow is resulting in pip version 22.3.1 which has a security vulnerability:
```
Found 1 known vulnerability in 1 package
Name Version ID             Fix Versions
---- ------- -------------- ------------
pip  22.3.1  PYSEC-2023-228 23.3
```

Removing `ensurepip`  results in using pip version 24.0, which does not have the vulnerability:
```
pip                       24.0               pyhd8ed1ab_0    conda-forge
```

Since the pip version is not really germane to the tests, the `ensurepip` call has been removed.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
