### PR TITLE
Remove gettext from test workflow, add MacOS ARM build

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -344,7 +344,6 @@ jobs:
       - name: Run tests
         run: |
           python -m pip install testflo parameterized six
-          conda install -y -q gettext
 
           echo "============================================================="
           echo "Run tests from pyoptsparse repository"

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -81,7 +81,7 @@ jobs:
             SCIPY: '1.13'
             MPICC: 4
             PYOPTSPARSE: 'default'
-            PAROPT: true
+            # PAROPT: true
             SNOPT: 7.7
 
           # test latest versions
@@ -136,15 +136,15 @@ jobs:
             FORCE_BUILD: true
 
           # test baseline versions on MacOS latest (ARM64)
-          # - NAME: MacOS Baseline on ARM
-          #   OS: macos-latest
-          #   PY: '3.12'
-          #   NUMPY: '1.26'
-          #   SCIPY: '1.13'
-          #   MPI4PY: true
-          #   PYOPTSPARSE: 'default'
-          #   PAROPT: true
-          #   SNOPT: 7.7
+          - NAME: MacOS Baseline on ARM
+            OS: macos-latest
+            PY: '3.12'
+            NUMPY: '1.26'
+            SCIPY: '1.13'
+            BREW: true
+            MPICC: 4
+            PYOPTSPARSE: 'default'
+            SNOPT: 7.7
 
     runs-on: ${{ matrix.OS }}
 
@@ -195,7 +195,13 @@ jobs:
 
       - name: Install
         run: |
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} compilers cython swig -q -y
+          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+
+          if [[ "${{ matrix.BREW }}" ]]; then
+            brew install swig gcc meson
+          else
+            conda install compilers cython swig -q -y
+          fi
 
           echo "============================================================="
           echo "Install build_pyoptsparse"
@@ -209,7 +215,11 @@ jobs:
           echo "Install MPI"
           echo "============================================================="
 
-          conda install openmpi-mpicc=${{ matrix.MPICC }} mpi4py -q -y
+          if [[ "${{ matrix.BREW }}" ]]; then
+            brew install open-mpi mpi4py
+          else
+            conda install openmpi-mpicc=${{ matrix.MPICC }} mpi4py -q -y
+          fi
 
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
 
@@ -289,7 +299,7 @@ jobs:
           fi
 
           echo "build_pyoptsparse -v $BRANCH $FORCE_BUILD $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER"
-          build_pyoptsparse -v $BRANCH $FORCE_BUILD $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER
+          build_pyoptsparse -v $BRANCH $FORCE_BUILD $PAROPT $SNOPT $NO_IPOPT $LINEAR_SOLVER -d
 
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
@@ -302,6 +312,20 @@ jobs:
             echo "============================================================="
             cat $f
           done
+          if test -d /private/var/folders; then
+            for f in $(find /private/var/folders/ -name 'meson-log.txt'); do
+              echo "============================================================="
+              echo $f
+              echo "============================================================="
+              cat $f
+            done
+            for f in $(find /private/var/folders/ -name 'compile.log'); do
+              echo "============================================================="
+              echo $f
+              echo "============================================================="
+              cat $f
+            done
+          fi
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       #


### PR DESCRIPTION
### Summary

A follow up to PR #67

Installation of `gettext` from `conda-forge` is still causing `pip` to be downgraded from 24.0 to 22.3, which has a security vulnerability:
```
Found 1 known vulnerability in 1 package
Name Version ID             Fix Versions
---- ------- -------------- ------------
pip  22.3.1  PYSEC-2023-228 23.3
```

`gettext` is a `pyoptsparse` dependency that is only needed when building the documentation.  Since that is out of scope for this package, and we are able to run the test suite without this dependency, it's installation has been removed.


Also:
- Enabled the MacOS ARM build in the test workflow, using `brew` to install compilers
- Added MacOS specific directories to find meson build logs

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
