### PR TITLE
Updated version of pyOptSparse in the 'oldest' build of the test workflow

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -101,7 +101,7 @@ jobs:
             PY: 3.8
             NUMPY: 1.22
             SCIPY: 1.7
-            PYOPTSPARSE: 'v1.2'
+            PYOPTSPARSE: 'v2.9.0'
             NO_IPOPT: true
             SNOPT: 7.2
 

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -888,7 +888,8 @@ def copy_snopt_files(build_dirname):
     exclude_snopth_f = re.compile('.*snopth.f')
     for sfile in all_snopt_files:
         src_file = str(sfile)
-        if not exclude_snopth_f.match(src_file):
+        # copy source files, exclude any directories (e.g. f2py/)
+        if not exclude_snopth_f.match(src_file) and not sfile.is_dir():
             shutil.copy2(src_file, dest_dir)
 
     note_ok()


### PR DESCRIPTION
### Summary

Updated version of pyOptSparse in the 'oldest' build of the test workflow.

The previous oldest version was broken by an update to setuptools.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
