### PR TITLE
Change Numpy 1 workflows to use Python 3.12

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -87,7 +87,7 @@ jobs:
           # test latest versions
           - NAME: Ubuntu Latest
             OS: ubuntu-latest
-            PY: 3
+            PY: '3.12'
             NUMPY: 1
             SCIPY: 1
             MPICC: 4
@@ -129,7 +129,7 @@ jobs:
           # test latest versions without MPI with forced build
           - NAME: Ubuntu Latest, no MPI, forced build
             OS: ubuntu-latest
-            PY: 3
+            PY: '3.12'
             NUMPY: 1
             SCIPY: 1
             PYOPTSPARSE: 'latest'


### PR DESCRIPTION
### Summary

Change NumPy 1.x workflows to use Python  3.12, since Python  3.13 doesn't work with NumPy 1.x

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
