### PR TITLE
Ensure NumPy/Scipy are installed from conda-forge if using conda

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -27,8 +27,7 @@ on:
           - 'Ubuntu Default'
           - 'Ubuntu Default, no MPI'
           - 'Ubuntu Default, Numpy 2.x'
-          - 'MacOS Default (Intel)'
-          - 'MacOS Default (ARM), NumPy 2.x'
+          - 'MacOS Default, NumPy 2.x'
           - 'Ubuntu Latest'
           - 'Ubuntu Default, no SciPy'
           - 'MacOS Default, SciPy from PyPI'
@@ -88,19 +87,8 @@ jobs:
             # PAROPT: true
             SNOPT: 7.7
 
-          # test default pyoptsparse on MacOS Legacy (Intel), NumPy 1.x
-          - NAME: MacOS Default (Intel)
-            OS: macos-13
-            PY: '3.11'
-            NUMPY: '1.26'
-            SCIPY: '1.13'
-            MPI: true
-            PYOPTSPARSE: 'default'
-            # PAROPT: true
-            SNOPT: 7.7
-
           # test default pyoptsparse on MacOS latest (ARM), NumPy 2.x
-          - NAME: MacOS Default (ARM), NumPy 2.x
+          - NAME: MacOS Default, NumPy 2.x
             OS: macos-latest
             PY: '3.12'
             NUMPY: '1.26'
@@ -164,7 +152,7 @@ jobs:
 
           # test default pyoptsparse on MacOS without MPI with forced build
           - NAME: MacOS Default, no MPI, forced build
-            OS: macos-13
+            OS: macos-latest
             PY: '3.11'
             NUMPY: '1.26'
             SCIPY: '1.13'

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -33,7 +33,6 @@ on:
           - 'MacOS Default, SciPy from PyPI'
           - 'Ubuntu Oldest'
           - 'Ubuntu Default, no MPI, forced build'
-          - 'MacOS Default, no MPI, forced build'
           - 'Ubuntu Latest, no MPI, forced build'
         required: false
         default: ''
@@ -144,16 +143,6 @@ jobs:
           - NAME: Ubuntu Default, no MPI, forced build
             OS: ubuntu-latest
             PY: '3.12'
-            NUMPY: '1.26'
-            SCIPY: '1.13'
-            PYOPTSPARSE: 'default'
-            SNOPT: 7.7
-            FORCE_BUILD: true
-
-          # test default pyoptsparse on MacOS without MPI with forced build
-          - NAME: MacOS Default, no MPI, forced build
-            OS: macos-latest
-            PY: '3.11'
             NUMPY: '1.26'
             SCIPY: '1.13'
             PYOPTSPARSE: 'default'

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -30,6 +30,8 @@ on:
           - 'MacOS Default (Intel)'
           - 'MacOS Default (ARM), NumPy 2.x'
           - 'Ubuntu Latest'
+          - 'Ubuntu Default, no SciPy'
+          - 'MacOS Default, SciPy from PyPI'
           - 'Ubuntu Oldest'
           - 'Ubuntu Default, no MPI, forced build'
           - 'MacOS Default, no MPI, forced build'
@@ -112,9 +114,31 @@ jobs:
             OS: ubuntu-latest
             PY: 3.13
             NUMPY: 2.2
-            SCIPY: 1.15
+            SCIPY: 1.16
             MPI: true
             PYOPTSPARSE: 'latest'
+            # PAROPT: true
+            SNOPT: 7.7
+
+          # test default release of pyoptsparse, NumPy 2.x, no scipy
+          - NAME: Ubuntu Default, no SciPy
+            OS: ubuntu-latest
+            PY: 3.13
+            NUMPY: 2.2
+            MPI: true
+            PYOPTSPARSE: 'default'
+            # PAROPT: true
+            SNOPT: 7.7
+
+          # test default release of pyoptsparse, NumPy 2.x, scipy from pypi
+          - NAME: MacOS Default, SciPy from PyPI
+            OS: macos-latest
+            PY: '3.12'
+            NUMPY: '1.26'
+            SCIPY: '1.13'
+            SCIPY_FROM_PYPI: true
+            MPI: true
+            PYOPTSPARSE: 'default'
             # PAROPT: true
             SNOPT: 7.7
 
@@ -207,7 +231,33 @@ jobs:
 
       - name: Install
         run: |
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          if [[ "${{ matrix.NUMPY}}" ]]; then
+            if [[ "${{ matrix.SCIPY_FROM_PYPI }}" ]]; then
+              echo "============================================================="
+              echo "Install NumPy from PyPI"
+              echo "============================================================="
+              python -m pip install numpy==${{ matrix.NUMPY }}
+            else
+              echo "============================================================="
+              echo "Install NumPy from conda-forge"
+              echo "============================================================="
+              conda install numpy=${{ matrix.NUMPY }} -c conda-forge -q -y
+            fi
+          fi
+
+          if [[ "${{ matrix.SCIPY}}" ]]; then
+            if [[ "${{ matrix.SCIPY_FROM_PYPI }}" ]]; then
+              echo "============================================================="
+              echo "Install SciPy from PyPI"
+              echo "============================================================="
+              python -m pip install scipy==${{ matrix.SCIPY }}
+            else
+              echo "============================================================="
+              echo "Install SciPy from conda-forge"
+              echo "============================================================="
+              conda install scipy=${{ matrix.SCIPY }} -c conda-forge -q -y
+            fi
+          fi
 
           conda install cython swig compilers cmake meson liblapack openblas -q -y
 
@@ -246,8 +296,10 @@ jobs:
           python -c "import numpy; assert str(numpy.__version__).startswith(str(${{ matrix.NUMPY }})), \
                     f'Numpy version {numpy.__version__} is not the requested version (${{ matrix.NUMPY }})'"
 
-          python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
-                    f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
+          if [[ "${{ matrix.SCIPY}}" ]]; then
+            python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
+                      f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
+          fi
 
       - name: Build pyOptSparse
         run: |

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -159,7 +159,6 @@ jobs:
             PYOPTSPARSE: 'default'
             SNOPT: 7.7
             FORCE_BUILD: true
-            XCODE: '14.2'
 
           # test latest pyoptsparse without MPI with forced build
           - NAME: Ubuntu Latest, no MPI, forced build

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -1372,7 +1372,7 @@ def perform_install():
             numpy_version = numpy_info['version']
             if numpy_version is not None:
                 print(f"{yellow('NOTE:')} NumPy {numpy_version} is not installed from conda-forge, reinstalling it now.")
-                install_conda_pkg(f'numpy', version=numpy_version)
+                install_conda_pkg('numpy', version=numpy_version)
             else:
                 print(f"{yellow('NOTE:')} NumPy is not installed from conda-forge, installing it now.")
                 install_conda_pkg('numpy')
@@ -1382,7 +1382,7 @@ def perform_install():
             scipy_version = scipy_info['version']
             if scipy_version is not None:
                 print(f"{yellow('NOTE:')} Scipy {scipy_version} is not installed from conda-forge, reinstalling it now.")
-                install_conda_pkg(f'scipy', version=scipy_version)
+                install_conda_pkg('scipy', version=scipy_version)
             else:
                 print(f"{yellow('NOTE:')} Scipy is not installed from conda-forge, installing it now.")
                 install_conda_pkg('scipy')

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -9,7 +9,7 @@ import subprocess
 import tarfile
 from pathlib import Path, PurePath
 import tempfile
-from colors import *
+from colors import yellow, red, green, cyan, color
 from shutil import which
 from packaging.version import parse
 import numpy
@@ -369,7 +369,8 @@ def subst_env_for_path(path:str)->str:
         The possibly updated path.
     """
 
-    if opts['verbose'] is True: return path
+    if opts['verbose'] is True:
+        return path
 
     for testvar in ['TMPDIR', 'TMP_DIR', 'TEMP_DIR', 'CONDA_PREFIX', 'VIRTUAL_ENV']:
         if testvar in os.environ and re.match(os.environ[testvar], path) is not None:
@@ -709,7 +710,7 @@ def install_mumps_from_src():
     if not allow_build('mumps'):
         return
 
-    build_dir = git_clone('mumps')
+    git_clone('mumps')
     run_cmd(['./get.Mumps'])
 
     cnf_cmd_list = get_common_solver_config_cmd()
@@ -725,7 +726,7 @@ def install_paropt_from_src():
     """
     Git clone the PAROPT repo, build the library, and install it and the include files.
     """
-    build_dir = git_clone('paropt')
+    git_clone('paropt')
 
     # Use build defaults as per ParOpt instructions:
     Path('Makefile.in.info').rename('Makefile.in')
@@ -765,13 +766,16 @@ def install_ipopt_from_src(config_opts:list=None):
     if not allow_build('ipopt') or opts['include_ipopt'] is False:
         return
 
-    build_dir = git_clone('ipopt')
+    git_clone('ipopt')
     cnf_cmd_list = ['./configure', f'--prefix={opts["prefix"]}', '--disable-java']
 
     # Don't accidentally use PARDISO if it wasn't selected:
-    if opts['linear_solver'] != 'pardiso': cnf_cmd_list.append('--disable-pardisomkl')
+    if opts['linear_solver'] != 'pardiso':
+        cnf_cmd_list.append('--disable-pardisomkl')
 
-    if config_opts is not None: cnf_cmd_list.extend(config_opts)
+    if config_opts is not None:
+        cnf_cmd_list.extend(config_opts)
+
     note("Running configure")
     run_cmd(cmd_list=cnf_cmd_list)
     note_ok()
@@ -843,7 +847,7 @@ def install_hsl_from_src():
     if not allow_build('hsl'):
         return
 
-    build_dir = git_clone('hsl')
+    git_clone('hsl')
 
     # Extract the HSL tar file and rename the folder to 'coinhsl'
     # First, determine the name of the top-level folder:
@@ -984,7 +988,7 @@ def uninstall_built_item(build_key:str):
 
             try:
                 inc_dir.rmdir()
-            except:
+            except Exception:
                 pass
 
             note_ok()
@@ -1023,10 +1027,13 @@ def remove_conda_scripts():
     if conda_is_active() and opts['ignore_conda'] is False:
         note("Removing conda activate/deactivate scripts")
         act_path = Path(sys_info['conda_activate_dir']) / sys_info['conda_env_script']
-        if act_path.is_file(): act_path.unlink()
+        if act_path.is_file():
+            act_path.unlink()
 
         deact_path = Path(sys_info['conda_deactivate_dir']) / sys_info['conda_env_script']
-        if deact_path.is_file(): deact_path.unlink()
+        if deact_path.is_file():
+            deact_path.unlink()
+
         note_ok()
 
 def uninstall_built():
@@ -1036,7 +1043,8 @@ def uninstall_built():
     for build_key in ['ipopt', 'hsl', 'mumps', 'metis']:
         uninstall_built_item(build_key)
 
-    if opts['ignore_conda'] is False: remove_conda_scripts()
+    if opts['ignore_conda'] is False:
+        remove_conda_scripts()
 
 def uninstall_conda_pkgs():
     """ Attempt to remove packages previously installed by conda. """
@@ -1107,7 +1115,7 @@ def check_compiler_sanity():
     note_ok()
 
     if opts['include_paropt']:
-        note(f'Testing mpicxx')
+        note('Testing mpicxx')
         run_cmd(cmd_list=['mpicxx', '-o', 'hello_cxx_mpi', 'hello.cc'])
         run_cmd(cmd_list=['./hello_cxx_mpi'])
         note_ok()
@@ -1234,7 +1242,8 @@ def finish_setup():
 
     # Set an option with the parsed pyOptSparse version
     pos_ver_str = build_info['pyoptsparse']['branch']
-    if pos_ver_str[:1] == 'v': pos_ver_str = pos_ver_str[1:] # Drop the initial v
+    if pos_ver_str[:1] == 'v':
+        pos_ver_str = pos_ver_str[1:] # Drop the initial v
     opts['pyoptsparse_version'] = parse(pos_ver_str)
 
     # Change snopt_dir to an absolute path
@@ -1348,6 +1357,7 @@ def get_package_info(pkgname:str) -> dict:
         pass
     return info
 
+
 def perform_install():
     """ Initiate all the required actions in the script. """
 
@@ -1357,7 +1367,8 @@ def perform_install():
     if opts['uninstall']:
         announce('Uninstalling pyOptSparse and related packages')
         print(f'{yellow("NOTE:")} Some items may be listed even if not installed.')
-        if opts['ignore_conda'] is False: uninstall_conda_pkgs()
+        if opts['ignore_conda'] is False:
+            uninstall_conda_pkgs()
         uninstall_built()
         exit(0)
 


### PR DESCRIPTION
### Summary

A user was getting errors after running the script in a `conda` environment without first installing `SciPy` (see below). This was traced to the fact that `SciPy` was getting installed from `PyPI` (as a dependency of `pyoptsparse`) and that package seemed to be incompatible with the other packages  (e.g. `lapack`) that are installed from `conda-forge` by the script.

This change will install `NumPy` and `Scipy` from `conda-forge` before installing `pyoptsparse` if they are not installed, or re-install them from `conda-forge` if they were previously installed from `PyPI`.  This only happens when `conda` is enabled.

Tests were added to the GitHub workflow to exercise these scenarios.

Also:
- one of the tests in the matrix was updated to test with `SciPy 1.16`, which was released recently.

```
Traceback (most recent call last):
  File "/Users/hschilli/miniforge3/envs/aviary/lib/python3.13/site-packages/numpy/core/__init__.py", line 24, in <module>
    from . import multiarray
  File "/Users/hschilli/miniforge3/envs/aviary/lib/python3.13/site-packages/numpy/core/multiarray.py", line 10, in <module>
    from . import overrides
  File "/Users/hschilli/miniforge3/envs/aviary/lib/python3.13/site-packages/numpy/core/overrides.py", line 8, in <module>
    from numpy.core._multiarray_umath import (
        add_docstring,  _get_implementing_args, _ArrayFunctionDispatcher)
ImportError: dlopen(/Users/hschilli/miniforge3/envs/aviary/lib/python3.13/site-packages/numpy/core/_multiarray_umath.cpython-313-darwin.so, 0x0002): Symbol not found: _cblas_caxpy$NEWLAPACK
  Referenced from: <27F2E2CD-A30E-38A6-A06C-0F5D7A0C22DC> /Users/hschilli/miniforge3/envs/aviary/lib/python3.13/site-packages/numpy/core/_multiarray_umath.cpython-313-darwin.so
  Expected in:     <3B8CB844-AEA9-37CA-901A-0BDC04DC268D> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
