### PR TITLE
Pinned compilers version in test workflow to 1.10

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -235,7 +235,7 @@ jobs:
             fi
           fi
 
-          conda install cython swig compilers cmake meson liblapack openblas -q -y
+          conda install cython swig compilers=1.10 cmake meson liblapack openblas -q -y
 
           if [[ "${{ matrix.XCODE }}" ]]; then
             sudo xcode-select -s "/Applications/Xcode_${{ matrix.XCODE }}.app"

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -1377,7 +1377,7 @@ def perform_install():
     announce('Beginning installation')
 
     # if using conda, we want numpy and scipy to be installed from conda-forge
-    if allow_install_with_conda() and opts['force_build'] is False:
+    if allow_install_with_conda():
         numpy_info = get_package_info('numpy')
         if numpy_info['installed'] is False or numpy_info['origin'] != 'conda-forge':
             numpy_version = numpy_info['version']

--- a/build_pyoptsparse.py
+++ b/build_pyoptsparse.py
@@ -1377,7 +1377,7 @@ def perform_install():
     announce('Beginning installation')
 
     # if using conda, we want numpy and scipy to be installed from conda-forge
-    if allow_install_with_conda():
+    if allow_install_with_conda() and opts['force_build'] is False:
         numpy_info = get_package_info('numpy')
         if numpy_info['installed'] is False or numpy_info['origin'] != 'conda-forge':
             numpy_version = numpy_info['version']


### PR DESCRIPTION
### Summary

The `compilers` package on `conda-forge` was updated to `1.11.0` in the last few days and it broke the `--force-build` jobs in the test workflow.  This updates the workflow to use the previous `1.10.0` version.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
